### PR TITLE
Set 'language' value as code_type for literal blocks with force_highlighting

### DIFF
--- a/sphinx_markdown_builder/doctree2md.py
+++ b/sphinx_markdown_builder/doctree2md.py
@@ -498,6 +498,8 @@ class Translator(nodes.NodeVisitor):
     def visit_literal_block(self, node):
         self._escape_text = False
         code_type = node['classes'][1] if 'code' in node['classes'] else ''
+        if node.get('force_highlighting', False) and 'language' in node:
+            code_type = node['language']
         self.add('```' + code_type + '\n')
 
     def depart_literal_block(self, node):


### PR DESCRIPTION
Currently a literalinclude such as:

.. literalinclude:: ../../rips/examples/AppInfo.py
	:language: python

.. does not pass the python parameter into the resulting markdown code. This change fixes this.