### PR TITLE
Tidy up dependency info

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,3 @@ Sphinx==2.1.2
 docutils==0.14
 html2text==2018.1.9
 pydash==4.7.5
-typing==3.7.4

--- a/setup.py
+++ b/setup.py
@@ -1,22 +1,16 @@
 from codecs import open
 from os import path
 from setuptools import setup, find_packages
-from subprocess import check_output
 
 here = path.abspath(path.dirname(__file__))
 
-check_output(
-    'pandoc --from=markdown --to=rst --output=' + path.join(here, 'README.rst') + ' ' + path.join(here, 'README.md'),
-    shell=True
-)
-
-with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
+with open(path.join(here, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 install_requires = list()
 with open(path.join(here, 'requirements.txt'), 'r', encoding='utf-8') as f:
     for line in f.readlines():
-        install_requires.append(line)
+        install_requires.append(line.split("=")[0].strip("<~>"))
 
 setup(
     name='sphinx-markdown-builder',
@@ -26,6 +20,7 @@ setup(
     description='sphinx builder that outputs markdown files',
 
     long_description=long_description,
+    long_description_content_type="text/markdown",
 
     url='https://github.com/codejamninja/sphinx-markdown-builder',
 
@@ -44,9 +39,9 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
     ],
 
     keywords='sphinx docs documentation markdown',

--- a/sphinx_markdown_builder/markdown_builder.py
+++ b/sphinx_markdown_builder/markdown_builder.py
@@ -8,11 +8,6 @@ from sphinx.locale import __
 from sphinx.util import logging
 from sphinx.util.osutil import ensuredir, os_path
 
-if False:
-    from typing import Any, Dict, Iterator, Set, Tuple
-    from docutils import nodes
-    from sphinx.application import Sphinx
-
 logger = logging.getLogger(__name__)
 
 class MarkdownBuilder(Builder):


### PR DESCRIPTION
I'm keen to use this in Hypothesis, but the pinned dependencies are a problem for us.  This therefore unpins them in `setup.py`.  That fixes #1; and replaces #6 which was undone by 7306882c07fa95a120b8e8cb0f6506e78007897c.

While in the area, I got `setup.py` to use the Markdown readme directly so you don't need `pandoc` installed; removed the totally unused dependency on `typing`; and fixed the Python version specs to be current versions of Python 3.