### PR TITLE
Escaping '__' coming from python methods

### DIFF
--- a/sphinx_markdown_builder/markdown_writer.py
+++ b/sphinx_markdown_builder/markdown_writer.py
@@ -68,6 +68,9 @@ class MarkdownTranslator(Translator):
 
     def visit_desc_name(self, node):
         # name of the class/method
+        # Escape "__" which is a formating string for markdown
+        if node.rawsource.startswith("__"):
+            self.add('\\')
         pass
 
     def depart_desc_name(self, node):


### PR DESCRIPTION
Python specials methods like constructors starts with '__' which is a bold tag for markdown, so this tag is now escaped.