### PR TITLE
Classes and methods are not at the same title level

### DIFF
--- a/sphinx_markdown_builder/markdown_writer.py
+++ b/sphinx_markdown_builder/markdown_writer.py
@@ -84,7 +84,11 @@ class MarkdownTranslator(Translator):
 
     def visit_desc_signature(self, node):
         # the main signature of class/method
-        self.add('\n#### ')
+        # We dont want methods to be at the same level as classes
+        if (node.attributes["class"]):
+            self.add('\n### ')
+        else:
+            self.add('\n#### ')
 
     def depart_desc_signature(self, node):
         # the main signature of class/method


### PR DESCRIPTION
Today, when generating markdown files, classes and methods from theses classes appears at the same title level which is kind of annoying.
I put classes at a higher level than methods to fix this.