### PR TITLE
Class are now at a superior title level than methods

### DIFF
--- a/sphinx_markdown_builder/markdown_writer.py
+++ b/sphinx_markdown_builder/markdown_writer.py
@@ -87,11 +87,13 @@ class MarkdownTranslator(Translator):
 
     def visit_desc_signature(self, node):
         # the main signature of class/method
-        # We dont want methods to be at the same level as classes
+        # We dont want methods to be at the same level as classes,
+        # If signature has a non null class, thats means it is a signature
+        # of a class method
         if ("class" in node.attributes and node.attributes["class"]):
-            self.add('\n### ')
-        else:
             self.add('\n#### ')
+        else:
+            self.add('\n### ')
 
     def depart_desc_signature(self, node):
         # the main signature of class/method


### PR DESCRIPTION
When I did PR #38 I made a mistake resulting in classes being at an inferior title level than methods while the opposite was expected.
It is now fixed