### PR TITLE
Keeping language annotations in code blocks 

### DIFF
--- a/sphinx_markdown_builder/doctree2md.py
+++ b/sphinx_markdown_builder/doctree2md.py
@@ -491,7 +491,7 @@ class Translator(nodes.NodeVisitor):
     def visit_literal_block(self, node):
         self._escape_text = False
         code_type = node['classes'][1] if 'code' in node['classes'] else ''
-        if node.get('force_highlighting', False) and 'language' in node:
+        if node.get('force', False) and 'language' in node:
             code_type = node['language']
         self.add('```' + code_type + '\n')
 


### PR DESCRIPTION
Inspecting the literal nodes (using Sphinx version 2.4.4) the `'force_highlight'` attribute does not exist. Looking at [this pull request](https://github.com/sphinx-doc/sphinx/pull/6416 ) merged in june 2019, it looks like `'force_highlight'` is replaced by `'force'`. So replacing the check on `'force_highlight'` by a check on the `'force'` attribute in `visit_literal_block`.
Fixes #13 