### PR TITLE
Allow all literals to use code highlighting.

### DIFF
--- a/sphinx_markdown_builder/doctree2md.py
+++ b/sphinx_markdown_builder/doctree2md.py
@@ -491,7 +491,7 @@ class Translator(nodes.NodeVisitor):
     def visit_literal_block(self, node):
         self._escape_text = False
         code_type = node['classes'][1] if 'code' in node['classes'] else ''
-        if node.get('force', False) and 'language' in node:
+        if 'language' in node:
             code_type = node['language']
         self.add('```' + code_type + '\n')
 


### PR DESCRIPTION
Currently, only literals with the `:force:` directive would actually benefit from code highlighting.

This change would allow all literals to benefit from the project's specified language for code blocks.

For example, this Python docstring...
```python
'''
Usage::

    import module
    module.dosomething()
'''
```
...will now render with code highlighting in markdown:

> Usage:
> 
> ```python
> import module
> module.dosomething(foo=5, bar='baz')
> ```