### PR TITLE
Changed the behavior of _refuri2http to return a refid fragment when markdown_http_base is None

### DIFF
--- a/sphinx_markdown_builder/doctree2md.py
+++ b/sphinx_markdown_builder/doctree2md.py
@@ -579,7 +579,7 @@ class Translator(nodes.NodeVisitor):
             return url
         # If HTTP page build URL known, make link relative to that.
         if not self.markdown_http_base:
-            return None
+            return f'#{node.get("refid")}'
         this_doc = self.builder.current_docname
         if url in (None, ''):  # Reference to this doc
             url = self.builder.get_target_uri(this_doc)


### PR DESCRIPTION
HI 👋
I noticed that some RST internal cross-references like ``:py:func:`my_func` ``
would get written to markdown like so `` `my_func()` ``
instead of the expected `` [`my_func()`](#my_func) ``

Looks like when `self.markdown_http_base` is None, the reference becomes None. Is this the intended behavior? Feel free to ignore/close this PR if so, otherwise, here's a simple fix.