### PR TITLE
Fix markdown links

### DIFF
--- a/sphinx_markdown_builder/doctree2md.py
+++ b/sphinx_markdown_builder/doctree2md.py
@@ -579,7 +579,7 @@ class Translator(nodes.NodeVisitor):
             return url
         # If HTTP page build URL known, make link relative to that.
         if not self.markdown_http_base:
-            return f'#{node.get("refid")}'
+            return node.get("refuri")
         this_doc = self.builder.current_docname
         if url in (None, ''):  # Reference to this doc
             url = self.builder.get_target_uri(this_doc)

--- a/sphinx_markdown_builder/markdown_builder.py
+++ b/sphinx_markdown_builder/markdown_builder.py
@@ -1,5 +1,3 @@
-from docutils import nodes
-
 from .markdown_writer import MarkdownWriter, MarkdownTranslator
 from docutils.io import StringOutput
 from io import open
@@ -7,7 +5,7 @@ from os import path
 from sphinx.builders import Builder
 from sphinx.locale import __
 from sphinx.util import logging
-from sphinx.util.osutil import ensuredir, os_path, relative_uri
+from sphinx.util.osutil import ensuredir, os_path
 
 logger = logging.getLogger(__name__)
 

--- a/sphinx_markdown_builder/markdown_builder.py
+++ b/sphinx_markdown_builder/markdown_builder.py
@@ -1,12 +1,13 @@
+from docutils import nodes
+
 from .markdown_writer import MarkdownWriter, MarkdownTranslator
 from docutils.io import StringOutput
 from io import open
 from os import path
 from sphinx.builders import Builder
-from sphinx.builders import Builder
 from sphinx.locale import __
 from sphinx.util import logging
-from sphinx.util.osutil import ensuredir, os_path
+from sphinx.util.osutil import ensuredir, os_path, relative_uri
 
 logger = logging.getLogger(__name__)
 
@@ -43,8 +44,9 @@ class MarkdownBuilder(Builder):
             except EnvironmentError:
                 pass
 
-    def get_target_uri(self, docname, typ=None):
-        return ''
+    def get_target_uri(self, docname: str, typ=None):
+        # Returns the target markdown file name
+        return f"{docname}.md"
 
     def prepare_writing(self, docnames):
         self.writer = MarkdownWriter(self)


### PR DESCRIPTION
Cross references between markdown files created from auto-generated documentation via sphinx-apidoc were all listed as `[...](#None)`.

This was due to faulty return values for markdown_builder.get_target_uri() and doctree2md._refuri2http().

See #20