### PR TITLE
translator fixes related to links, literals, and titles

### DIFF
--- a/sphinx_markdown_builder/markdown_builder.py
+++ b/sphinx_markdown_builder/markdown_builder.py
@@ -21,6 +21,7 @@ class MarkdownBuilder(Builder):
     current_docname = None
 
     markdown_http_base = 'https://localhost'
+    insert_anchors_for_signatures = False
 
     def init(self):
         self.secnumbers = {}

--- a/sphinx_markdown_builder/markdown_writer.py
+++ b/sphinx_markdown_builder/markdown_writer.py
@@ -8,6 +8,7 @@ import sys
 
 h = html2text.HTML2Text()
 
+
 class MarkdownTranslator(Translator):
     depth = Depth()
     enumerated_count = {}
@@ -16,7 +17,7 @@ class MarkdownTranslator(Translator):
     tables = []
     tbodys = []
     theads = []
-    
+
     def __init__(self, document, builder=None):
         Translator.__init__(self, document, builder=None)
         self.builder = builder
@@ -55,9 +56,11 @@ class MarkdownTranslator(Translator):
         self.add('_')
 
     def depart_desc_annotation(self, node):
-        # annotation, e.g 'method', 'class'
-        self.get_current_output('body')[-1] = self.get_current_output('body')[-1][:-1]
+        # annotation, e.g 'method', 'class', or a signature
+        stripped = self.get_current_output('body')[-1].strip()
+        self.get_current_output('body')[-1] = stripped
         self.add('_ ')
+
     def visit_desc_addname(self, node):
         # module preroll for class/method
         pass
@@ -87,6 +90,12 @@ class MarkdownTranslator(Translator):
 
     def visit_desc_signature(self, node):
         # the main signature of class/method
+
+        # Insert anchors if enabled by the builder
+        if self.builder.insert_anchors_for_signatures:
+            for sig_id in node.get("ids", ()):
+                self.add('<a name="{}"></a>'.format(sig_id))
+
         # We dont want methods to be at the same level as classes,
         # If signature has a non null class, thats means it is a signature
         # of a class method


### PR DESCRIPTION
1. Turn off escaping when inside of `inline literals`, same as with
```
block literals
```
2. Strip only whitespaces in `visit_desc_signature` (sometimes it would strip a part of the signature - reproduced with autodoc classes).
3. `_refuri2http` should be able to process links consisting of only the anchor (`refid`), like `#some-title-on-the-same-page`. Before this fix it would return an empty string as a URL.
4. Add an option to insert anchors for every signature, right above the title.