### PR TITLE
Fix new line insertion  inside table cells text

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Byte-compiled / optimized / DLL files
 __pycache__/
+.vscode/
 *.py[cod]
 *$py.class
 

--- a/sphinx_markdown_builder/__init__.py
+++ b/sphinx_markdown_builder/__init__.py
@@ -1,4 +1,14 @@
 from .markdown_builder import MarkdownBuilder
+from sphinx.util.osutil import make_filename
 
 def setup(app):
     app.add_builder(MarkdownBuilder)
+    def default_md_documents(conf):
+        start_doc = conf.master_doc
+        filename = '%s.md' % make_filename(conf.project)
+        toc_only = False
+        return [(start_doc, filename, toc_only)]
+    
+    app.add_config_value('md_documents', default_md_documents, 'env') 
+    app.add_config_value('md_insert_html', True, 'env')   
+    

--- a/sphinx_markdown_builder/__init__.py
+++ b/sphinx_markdown_builder/__init__.py
@@ -1,6 +1,54 @@
 from .markdown_builder import MarkdownBuilder
 from sphinx.util.osutil import make_filename
 
+
+from sphinx.application import Sphinx
+from sphinx.environment import BuildEnvironment
+from sphinx.util import DownloadFiles, FilenameUniqDict, logging
+from typing import (TYPE_CHECKING, Any, Callable, Dict, Generator, Iterator, List, Optional,
+                    Set, Tuple, Union)
+
+# logger = logging.getLogger(__name__)
+
+# def check_doclist(app: "Sphinx", env: "BuildEnvironment", added: Set[str],
+#                    changed: Set[str], removed: Set[str]):
+    
+#     if env.config.md_singledoc:
+        
+#         print(">>>> check_doclist env.all_docs=", env.all_docs)
+#         print(">>>> check_doclist env.found_docs=", env.found_docs)
+        
+#         added =[]
+#         changed = []
+#         removed = []
+        
+#         for entry in env.config.md_documents:
+#             current_docname, out_docfile = entry[:2]
+#             for doc in env.found_docs:
+#                 if doc != current_docname:
+#                     removed.append(doc)
+        
+        
+        
+#         if added:
+#             for the_doc in added:
+#                 print ("check_doclist ADD=",the_doc)
+
+#         if changed:
+#             for the_doc in changed:
+#                 print ("check_doclist CHANGE=",the_doc)
+
+#         if removed:
+#             for the_doc in removed:
+#                 print ("check_doclist REMOVE=",the_doc)
+
+
+#     return removed
+
+
+
+
+
 def setup(app):
     app.add_builder(MarkdownBuilder)
     def default_md_documents(conf):
@@ -9,6 +57,10 @@ def setup(app):
         toc_only = True
         return [(start_doc, filename, toc_only)]
     
+    #  Register event callback befor read and add to catalog
+    # app.connect('env-get-outdated', check_doclist)
+    
     app.add_config_value('md_documents', default_md_documents, 'env') 
-    app.add_config_value('md_insert_html', True, 'env')   
+    app.add_config_value('md_insert_html', True, 'env') 
+    app.add_config_value('md_singledoc', True, 'env')   
     

--- a/sphinx_markdown_builder/__init__.py
+++ b/sphinx_markdown_builder/__init__.py
@@ -6,7 +6,7 @@ def setup(app):
     def default_md_documents(conf):
         start_doc = conf.master_doc
         filename = '%s.md' % make_filename(conf.project)
-        toc_only = False
+        toc_only = True
         return [(start_doc, filename, toc_only)]
     
     app.add_config_value('md_documents', default_md_documents, 'env') 

--- a/sphinx_markdown_builder/doctree2md.py
+++ b/sphinx_markdown_builder/doctree2md.py
@@ -419,6 +419,10 @@ class Translator(nodes.NodeVisitor):
         text = node.astext().replace('\r\n', '\n')
         if self._escape_text:
             text = self.escape_chars(text)
+            
+        ### for muliline text, placed inside table cell rplace new line with HTML <BR>    
+        if isinstance(node.parent, nodes.paragraph) and isinstance(node.parent.parent, nodes.entry):    
+            text = node.astext().replace('\n', '<br>')    
         self.add(text)
 
     def depart_Text(self, node):
@@ -456,8 +460,10 @@ class Translator(nodes.NodeVisitor):
         pass
 
     def depart_paragraph(self, node):
-        self.ensure_eol()
-        self.add('\n')
+        ## Inside table cell does not need to add line break
+        if type(node.parent) != nodes.entry:
+            self.ensure_eol()
+            self.add('\n')
 
     def visit_math_block(self, node):
         # docutils math block

--- a/sphinx_markdown_builder/doctree2md.py
+++ b/sphinx_markdown_builder/doctree2md.py
@@ -460,10 +460,9 @@ class Translator(nodes.NodeVisitor):
         pass
 
     def depart_paragraph(self, node):
-        ## Inside table cell does not need to add line break
-        if type(node.parent) != nodes.entry:
-            self.ensure_eol()
-            self.add('\n')
+        
+        self.ensure_eol()
+        self.add('\n')
 
     def visit_math_block(self, node):
         # docutils math block

--- a/sphinx_markdown_builder/markdown_builder.py
+++ b/sphinx_markdown_builder/markdown_builder.py
@@ -1,11 +1,17 @@
 from .markdown_writer import MarkdownWriter, MarkdownTranslator
 from docutils.io import StringOutput
+from docutils import nodes
+from docutils.frontend import OptionParser
 from io import open
 from os import path
 from sphinx.builders import Builder
 from sphinx.locale import __
-from sphinx.util import logging
+from sphinx.util import isurl, logging, md5, progress_message, status_iterator
 from sphinx.util.osutil import ensuredir, os_path
+from sphinx.application import Sphinx
+from sphinx.environment.adapters.asset import ImageAdapter
+from sphinx.util.osutil import copyfile, ensuredir, os_path, relative_uri
+from typing import IO, Any, Dict, Iterable, Iterator, List, Set, Tuple, Type
 
 logger = logging.getLogger(__name__)
 
@@ -13,17 +19,22 @@ class MarkdownBuilder(Builder):
     name = 'markdown'
     format = 'markdown'
     epilog = __('The markdown files are in %(outdir)s.')
-
     out_suffix = '.md'
     allow_parallel = True
     default_translator_class = MarkdownTranslator
-
     current_docname = None
-
     markdown_http_base = 'https://localhost'
+    imgpath: str = None
+    supported_image_types = ['image/svg+xml', 'image/png',
+                             'image/gif', 'image/jpeg']
+    search = True  # for things like HTML help and Apple help: suppress search
+    use_index = False
 
     def init(self):
         self.secnumbers = {}
+        # basename of images directory
+        self.imagedir = '_images'
+        
 
     def get_outdated_docs(self):
         for docname in self.env.found_docs:
@@ -46,24 +57,77 @@ class MarkdownBuilder(Builder):
         # Returns the target markdown file name
         return f"{docname}.md"
 
+    # def get_target_uri(self, docname: str, typ: str = None) -> str:
+    #     return quote(docname) + self.link_suffix
+
+
+
     def prepare_writing(self, docnames):
+        # create the search indexer
+        self.indexer = None
+        if self.search:
+            from sphinx.search import IndexBuilder
+            lang = self.config.html_search_language or self.config.language
+            if not lang:
+                lang = 'en'
+            self.indexer = IndexBuilder(self.env, lang,
+                                        self.config.html_search_options,
+                                        self.config.html_search_scorer)
+
+        
         self.writer = MarkdownWriter(self)
+        # self.docsettings: Any = OptionParser(defaults=self.env.settings,components=(self.docwriter,),read_config_files=True).get_default_values()
+
 
     def write_doc(self, docname, doctree):
         self.current_docname = docname
         self.secnumbers = self.env.toc_secnumbers.get(docname, {})
+        self.fignumbers = self.env.toc_fignumbers.get(docname, {})
         destination = StringOutput(encoding='utf-8')
+        
         self.writer.write(doctree, destination)
-        outfilename = path.join(
-            self.outdir,
-            os_path(docname) + self.out_suffix
-        )
+        outfilename = path.join(self.outdir,os_path(docname) + self.out_suffix)
         ensuredir(path.dirname(outfilename))
+        
         try:
             with open(outfilename, 'w', encoding='utf-8') as f:  # type: ignore
                 f.write(self.writer.output)
         except (IOError, OSError) as err:
             logger.warning(__('error writing file %s: %s'), outfilename, err)
+            
+            
+    def write_doc_serialized(self, docname: str, doctree: nodes.document):
+        self.imgpath = relative_uri(self.get_target_uri(docname), self.imagedir)
+        self.post_process_images(doctree)
+        
 
+    def copy_image_files(self):
+        if self.images:
+            stringify_func = ImageAdapter(self.app.env).get_original_image_uri
+            ensuredir(path.join(self.outdir, self.imagedir))
+            for src in status_iterator(self.images, __('copying images... '), "brown",
+                                       len(self.images), self.app.verbosity,
+                                       stringify_func=stringify_func):
+                dest = self.images[src]
+                try:
+                    copyfile(path.join(self.srcdir, src),
+                             path.join(self.outdir, self.imagedir, dest))
+                except Exception as err:
+                    logger.warning(__('cannot copy image file %r: %s'),
+                                   path.join(self.srcdir, src), err)
+
+
+    # def finish(self):
     def finish(self):
-        pass
+        self.finish_tasks.add_task(self.copy_image_files)
+
+
+def setup(app: Sphinx) -> Dict[str, Any]:
+    app.add_builder(MarkdownBuilder)
+    app.setup_extension('sphinx.builders.md')
+
+    return {
+        'version': 'builtin',
+        'parallel_read_safe': True,
+        'parallel_write_safe': True,
+    }

--- a/sphinx_markdown_builder/markdown_builder.py
+++ b/sphinx_markdown_builder/markdown_builder.py
@@ -99,7 +99,7 @@ class MarkdownBuilder(Builder):
         self.env.resolve_references(tree, master, self)
         
   
-    
+    ####   ??????
     def fix_refuris(self, tree: Node):
         # fix refuris with double anchor
         fname = self.config.root_doc + self.out_suffix
@@ -132,9 +132,9 @@ class MarkdownBuilder(Builder):
                     TransClassList[i] =  ReferencesResolverNew
         
         self.env.resolve_references(tree, master, self) 
-        self.fix_refuris(tree)
-        print (">>>> ASSWMBLE DOCTREE ", tree )
-        print (">>>> ASSWMBLE DOCTREE ----------------------------------------------------------------")
+        # self.fix_refuris(tree)
+        # print (">>>> ASSWMBLE DOCTREE ", tree )
+        # print (">>>> ASSWMBLE DOCTREE ----------------------------------------------------------------")
         return tree         
             
     def assemble_toc_secnumbers(self,master):
@@ -154,7 +154,7 @@ class MarkdownBuilder(Builder):
                 alias = "%s/%s" % (docname, id)
                 new_secnumbers[alias] = secnum
 
-        print (">>>> assemble_toc_secnumbers ", new_secnumbers)
+        # print (">>>> assemble_toc_secnumbers ", new_secnumbers)
         return new_secnumbers
         # return {master: new_secnumbers}
 
@@ -169,7 +169,7 @@ class MarkdownBuilder(Builder):
         #
         #       There are related codes in inline_all_toctres() and
         #       HTMLTranslter#add_fignumber().
-        print("ASSEMBLE TOC_FIGNUMBERS Source - self.env.toc_fignumbers",self.env.toc_fignumbers.items())
+        # print("ASSEMBLE TOC_FIGNUMBERS Source - self.env.toc_fignumbers",self.env.toc_fignumbers.items())
         
         new_fignumbers: Dict[str, Dict[str, Tuple[int, ...]]] = {}
         # {'foo': {'figure': {'id2': (2,), 'id1': (1,)}}, 'bar': {'figure': {'id1': (3,)}}}
@@ -180,7 +180,7 @@ class MarkdownBuilder(Builder):
                 for id, fignum in fignums.items():
                     new_fignumbers[alias][id] = fignum
                     
-        print (">>>> assemble_toc_fignumbers ", new_fignumbers)
+        # print (">>>> assemble_toc_fignumbers ", new_fignumbers)
         return new_fignumbers
         # return {master: new_fignumbers}
 
@@ -194,8 +194,8 @@ class MarkdownBuilder(Builder):
             toctree_only = entry[2] if len(entry) > 3 else False
 
             # logger.info('preparing documents... ', nonl=True)
-            print('>>>> DOC LIST ',  self.current_docname)
-            print('>>>> WRITE ------------------------------------------------------------------------------------ ')
+            # print('>>>> DOC LIST ',  self.current_docname)
+            # print('>>>> WRITE ------------------------------------------------------------------------------------ ')
             
             self.writer = MarkdownWriter(self)
             # self.prepare_writing(docnames)
@@ -206,7 +206,7 @@ class MarkdownBuilder(Builder):
             self.env.toc_fignumbers = self.assemble_toc_fignumbers(self.current_docname)
             # logger.info('done')
             # print(">>>> ASSEMBLE toc_secnumbers  ", self.env.toc_secnumbers )
-            # print(">>>> ASSEMBLE toc_fignumbers  ", self.env.toc_fignumbers )
+            print(">>>> ASSEMBLE toc_fignumbers  ", self.env.toc_fignumbers )
 
             # logger.info('processing %s... ' % out_docfile, nonl=True)
             # doctree = self.assemble_doctree(start_doc, toctree_only)
@@ -222,6 +222,9 @@ class MarkdownBuilder(Builder):
             
     def write_doc(self, docname, doctree,out_docfile):
         # self.current_docname = docname
+        print (">>>> WRITE DOC ---------------------------------------------------------\n",
+            doctree, 
+            "\n---------------------------------------------------------")
         
         self.resolve_ref(doctree, docname)
     
@@ -396,13 +399,13 @@ def _resolve_numref_xref_new(self,
     try:
         
         
-        print (">>>> _resolve_numref_xref_new 1",
-            "\n    env= ",env,
-            "\n    builder= ",builder,
-            "\n    figtype=",figtype,
-            "\n    docname=",docname,
-            "\n    target_node=",target_node
-            )
+        # print (">>>> _resolve_numref_xref_new 1",
+        #     "\n    env= ",env,
+        #     "\n    builder= ",builder,
+        #     "\n    figtype=",figtype,
+        #     "\n    docname=",docname,
+        #     "\n    target_node=",target_node
+        #     )
         
         
         # fignumber = self.get_fignumber(env, builder, figtype, docname, target_node)
@@ -411,13 +414,13 @@ def _resolve_numref_xref_new(self,
         figure_id = target_node['ids'][0]
         fignumber = 'undef'
         
-        print (">>>> _resolve_numref_xref_new 2",
-            "\n    -----------",              
-            "\n    env.toc_fignumbers=",env.toc_fignumbers,
-            "\n    figure_id=",figure_id,
-            "\n    labelid=",labelid,
-            "\n    fignumber=",fignumber
-            )
+        # print (">>>> _resolve_numref_xref_new 2",
+        #     "\n    -----------",              
+        #     "\n    env.toc_fignumbers=",env.toc_fignumbers,
+        #     "\n    figure_id=",figure_id,
+        #     "\n    labelid=",labelid,
+        #     "\n    fignumber=",fignumber
+        #     )
                 
                 
         #  from self.get_fignumber(env, builder, figtype, docname, target_node) 

--- a/sphinx_markdown_builder/markdown_builder.py
+++ b/sphinx_markdown_builder/markdown_builder.py
@@ -79,7 +79,7 @@ class MarkdownBuilder(Builder):
             
             
     def get_target_uri(self, docname: str, typ: str = None):
-        if docname not in self.docnames:
+        if docname not in self.env.all_docs:
             raise NoUri(docname, typ)
         else:
             return docname   + self.out_suffix
@@ -98,39 +98,7 @@ class MarkdownBuilder(Builder):
         
         self.env.resolve_references(tree, master, self)
         
-                
-    # def assemble_doctree(self, master, toctree_only):
-    #     tree = self.env.get_doctree(master)
-    #     if toctree_only:
-    #         doc = new_document('mdbuilder/builder.py')
-    #         for toctree in tree.traverse(addnodes.toctree):
-    #             # ids is not assigned to toctree, but to the parent
-    #             toctree.get('ids').extend(toctree.parent.get('ids'))
-    #             doc.append(toctree)
-    #         tree = doc
-    #     tree = inline_all_toctrees(self, set(), master, tree, darkgreen, [master])    
-    #     # tree = insert_all_toctrees(tree, self.env, [])
-    #     tree['docname'] = master
-    #     logger.info('')
-    #     logger.info('resolving references...', nonl=True)
-    #     print ("Apply post transforms ",self.app.registry.get_post_transforms())
-    #     self.env.resolve_references(tree, master, self)
-    #     # self.fix_refuris(tree)
-    #     print("\n>>>> PRINT TOCTREE ",tree )
-    
-    #     # TODO: Support cross references
-    #     return tree
-    
-    # def assemble_doctree(self, docname):
-    #     print (">>>> ASEMBLE DOCTREE ", docname)
-    #     tree = self.env.get_doctree(docname)
-    #     tree = inline_all_toctrees(self, set(), docname, tree, darkgreen, [docname])
-    #     tree['docname'] = docname
-    #     print("self.md_documents ",self.md_documents )
-    #     print (">>>> DOCTREE ", tree )
-    #     print (">>>> DOCTREE ----------------------------------------------------------------")
-    #     return tree
-
+  
     
     def fix_refuris(self, tree: Node):
         # fix refuris with double anchor
@@ -250,21 +218,7 @@ class MarkdownBuilder(Builder):
             self.write_doc(self.current_docname, doctree, out_docfile)
             # logger.info('done') 
  
-            
-            
-    # def prepare_writing(self, docnames):
-        # for entry in self.config.md_documents:
-        #     if entry[0] not in self.env.all_docs:
-        #         logger.warning('unknown document %s is found ' 'in md_documents' % entry[0])
-        #         continue
-        #     if not entry[1]:
-        #         logger.warning('invalid filename %s s found for %s ' 'in md_documents' % (entry[1]. entry[0]))
-        #         continue
-        #     self._doc_list.append(entry)
-            
-        # if not self._doc_list:
-        #     logger.warning('no valid entry is found in md_documents')
-        
+       
             
     def write_doc(self, docname, doctree,out_docfile):
         # self.current_docname = docname
@@ -303,80 +257,7 @@ class MarkdownBuilder(Builder):
         
         # Accomulate and check document used images
         Builder.post_process_images(self, doctree)    
-            
-            
-            
-            
-            
-            
-            
-            
-            
-            
-            
-            
-            
-
-
-
-    # def get_target_uri(self, docname: str, typ: str = None) -> str:
-    #     return quote(docname) + self.link_suffix
-
-
-
-
-
-
-
-
-
-
-    # def prepare_writing(self, docnames):
-    #     # create the search indexer
-    #     # self.docnames
-    #     self.indexer = None
-    #     if self.search:
-    #         from sphinx.search import IndexBuilder
-    #         lang = self.config.html_search_language or self.config.language
-    #         if not lang:
-    #             lang = 'en'
-    #         self.indexer = IndexBuilder(self.env, lang,
-    #                                     self.config.html_search_options,
-    #                                     self.config.html_search_scorer)
-
-        
-    #     self.writer = MarkdownWriter(self)
-    #     # self.docsettings: Any = OptionParser(defaults=self.env.settings,components=(self.docwriter,),read_config_files=True).get_default_values()
-
-
-    # def write_doc(self, docname, doctree):
-    #     self.current_docname = docname
-    #     self.secnumbers = self.env.toc_secnumbers.get(docname, {})
-    #     self.fignumbers = self.env.toc_fignumbers.get(docname, {})
-    #     print( ">>> WRITE_DOC docname=",docname,"\n    fignumbers=",self.fignumbers)
-        
-        
-    #     destination = StringOutput(encoding='utf-8')
-        
-    #     self.writer.write(doctree, destination)
-    #     outfilename = path.join(self.outdir,os_path(docname) + self.out_suffix)
-    #     ensuredir(path.dirname(outfilename))
-        
-    #     try:
-    #         with open(outfilename, 'w', encoding='utf-8') as f:  # type: ignore
-    #             f.write(self.writer.output)
-    #     except (IOError, OSError) as err:
-    #         logger.warning(__('error writing file %s: %s'), outfilename, err)
-            
-            
-    # def write_doc_serialized(self, docname: str, doctree: nodes.document):
-    #     self.imgpath = relative_uri(self.get_target_uri(docname), self.imagedir)
-    #     self.post_process_images(doctree)
-        
-        
-    # def post_process_images(self, doctree: Node):
-    #     if      
-        
+       
 
     def copy_image_files(self):
         if self.images:
@@ -400,30 +281,30 @@ class MarkdownBuilder(Builder):
 
 
 
-### ?????
-def insert_all_toctrees(tree, env, traversed):
-    tree = tree.deepcopy()
-    for toctreenode in tree.traverse(addnodes.toctree):
-        nodeid = 'docx_expanded_toctree%d' % id(toctreenode)
-        newnodes = nodes.container(ids=[nodeid])
-        toctreenode['docx_expanded_toctree_refid'] = nodeid
-        includefiles = toctreenode['includefiles']
-        for includefile in includefiles:
-            if includefile in traversed:
-                continue
-            try:
-                traversed.append(includefile)
-                subtree = insert_all_toctrees(
-                        env.get_doctree(includefile), env, traversed)
-            except Exception:
-                continue
-            start_of_file = addnodes.start_of_file(docname=includefile)
-            start_of_file.children = subtree.children
-            newnodes.append(start_of_file)
-        parent = toctreenode.parent
-        index = parent.index(toctreenode)
-        parent.insert(index + 1, newnodes)
-    return tree
+# ### ?????
+# def insert_all_toctrees(tree, env, traversed):
+#     tree = tree.deepcopy()
+#     for toctreenode in tree.traverse(addnodes.toctree):
+#         nodeid = 'docx_expanded_toctree%d' % id(toctreenode)
+#         newnodes = nodes.container(ids=[nodeid])
+#         toctreenode['docx_expanded_toctree_refid'] = nodeid
+#         includefiles = toctreenode['includefiles']
+#         for includefile in includefiles:
+#             if includefile in traversed:
+#                 continue
+#             try:
+#                 traversed.append(includefile)
+#                 subtree = insert_all_toctrees(
+#                         env.get_doctree(includefile), env, traversed)
+#             except Exception:
+#                 continue
+#             start_of_file = addnodes.start_of_file(docname=includefile)
+#             start_of_file.children = subtree.children
+#             newnodes.append(start_of_file)
+#         parent = toctreenode.parent
+#         index = parent.index(toctreenode)
+#         parent.insert(index + 1, newnodes)
+#     return tree
 
 
 
@@ -515,7 +396,7 @@ def _resolve_numref_xref_new(self,
     try:
         
         
-        print (">>>> _resolve_numref_xref_new",
+        print (">>>> _resolve_numref_xref_new 1",
             "\n    env= ",env,
             "\n    builder= ",builder,
             "\n    figtype=",figtype,
@@ -530,20 +411,22 @@ def _resolve_numref_xref_new(self,
         figure_id = target_node['ids'][0]
         fignumber = 'undef'
         
-        print (">>>> _resolve_numref_xref_new",
+        print (">>>> _resolve_numref_xref_new 2",
             "\n    -----------",              
             "\n    env.toc_fignumbers=",env.toc_fignumbers,
             "\n    figure_id=",figure_id,
+            "\n    labelid=",labelid,
             "\n    fignumber=",fignumber
             )
                 
                 
-        #  from self.get_fignumber(env, builder, figtype, docname, target_node)        
-        a = env.toc_fignumbers[docname]
-        
-        b = a[figtype]           
-        
-        fignumber = b[figure_id]
+        #  from self.get_fignumber(env, builder, figtype, docname, target_node) 
+        try:       
+            a = env.toc_fignumbers[docname]
+            b = a[figtype]           
+            fignumber = b[figure_id]
+        except:
+            pass    
         
         
         if fignumber is None:

--- a/sphinx_markdown_builder/markdown_writer.py
+++ b/sphinx_markdown_builder/markdown_writer.py
@@ -254,6 +254,8 @@ class MarkdownTranslator(Translator):
         self.tables.append(node)
 
     def depart_table(self, node):
+        ##  Better readable when table and folowing text are devided by line
+        self.add('\n')
         self.tables.pop()
 
     def visit_tabular_col_spec(self, node):

--- a/sphinx_markdown_builder/markdown_writer.py
+++ b/sphinx_markdown_builder/markdown_writer.py
@@ -102,7 +102,7 @@ class MarkdownTranslator(SphinxTranslator,Translator):
     def set_anchor(self,node):
         if self.builder.md_insert_html and node and len(node['ids']) != 0:
             for id in node['ids']:
-                self.add('<a name={}></a>'.format(id))
+                self.add('<a name="{}"></a>'.format(id))
             self.add('\n')
         
    
@@ -286,6 +286,7 @@ class MarkdownTranslator(SphinxTranslator,Translator):
 
     def visit_literal(self, node):
         print (">>>> VISIT LITERAL", node)
+        super().visit_literal(node)
         pass
 
 
@@ -334,6 +335,7 @@ class MarkdownTranslator(SphinxTranslator,Translator):
     def visit_image(self, node):
         """Image directive."""
         olduri = node['uri']
+        
         # rewrite the URI if the environment knows about it
         if olduri in self.builder.images:
             node['uri'] = posixpath.join(self.builder.imgpath,
@@ -364,7 +366,7 @@ class MarkdownTranslator(SphinxTranslator,Translator):
                 self.add('width: %s;' % node['width'])
             if node.get('align'):
                 self.add('align-%s;' % node['align'])
-            self.add('">\n')    
+            self.add('">')    
 
         # rewrite the URI if the environment knows about it
         # olduri = node['uri']
@@ -602,12 +604,14 @@ class MarkdownTranslator(SphinxTranslator,Translator):
     #     print (">>>>VISIT PENDING_XFER ", node)
     #     pass    
     
-    def visit_reference(self, node):
-        if self.builder.md_insert_html:
+    def visit_reference(self, node: Element):
+        print (">>>> VISIT REFERENCE ", node,"\n", node.attlist())
+        if self.builder.md_insert_html and node.hasattr('refid'):
             target_uri = ''
-            if node['internal'] and node['refid']:
+
+            if node['internal']:
                 target_uri = "#" + node['refid']
-            elif node['refid']:    
+            else:    
                 print (">>>>VISIT REFERENCE - EXTERNAL ", node)
                 target_uri=node['refid']
             self.add('<a href="{}">'.format(target_uri))


### PR DESCRIPTION
rst table construction:

```
.. table:: Тест
    ====== ==============================================================================
    х1      x2
    ====== ==============================================================================
    d1     d2
           d4
    d5     d6       
    ====== ==============================================================================
```

converted to wrong syntax 

```
. . . 
| d1  | d2
d4
|
. . . 
```
It is incorrect in terms of Markdown.   All table cell context should be in one line.
So I fix this.    I test it using  methods overload in  conf.py   in my current sphinx-doc documentation.

For mow it produce 
```
| х1 | x2 |
| ------ | ------------------------------------------------------------------------------ |
| d1 | d2<br>Переменные события пересечения порога для метрики объекта |
| d5 | d6 |
```
Unfortunately, It steels has problems with correct column width  detection ( made some trick  in this example)  and i  steel work on solution.




