### PR TITLE
Fix table and list item: paragraph in these nodes do not need newline

### DIFF
--- a/sphinx_markdown_builder/doctree2md.py
+++ b/sphinx_markdown_builder/doctree2md.py
@@ -456,6 +456,24 @@ class Translator(nodes.NodeVisitor):
         pass
 
     def depart_paragraph(self, node):
+        # A paragraph maybe child of a table entry, we should not add newline here
+        #
+        #   <row>
+        #     <entry>
+        #       <paragraph>
+        if isinstance(node.parent, nodes.entry):
+            return
+        # Also, a paragraph maybe child of a list item, we should not add new line
+        # when here is not last list item.
+        #
+        #    <bullet_list bullet="-">
+        #       <list_item>
+        #           <paragraph>
+        if isinstance(node.parent, nodes.list_item) and \
+                type(node.parent) == type(node.parent.next_node(descend=False, siblings=True)):
+            return
+        # print(type(node.parent), type(node.parent.next_node(descend=False, siblings=True, ascend=True)))
+
         self.ensure_eol()
         self.add('\n')
 


### PR DESCRIPTION
A paragraph maybe child of a table entry or list item, we should not add newline in these cases. See commit message and comments of code.

## Table

### rST source: 

```rst
.. list-table::
   :header-rows: 1

   * - Type
     - Variant
   * - ``any``
     - ``Stream``
   * - ``comparable``
     - ``Comparable``
```

### Generated markdown:

```md
| Type

 | Variant

 |
| ------------------- | ---------------------------------------------------------------- |  |  |
| `any`

                 | `Stream`

                                                           |
| `comparable`

          | `Comparable`

                                                       |
```

### After this patch:

```md
| Type | Variant |
| ------------------- | ---------------------------------------------------------------- |  |  |
| `any`                 | `Stream`                                                           |
| `comparable`          | `Comparable`                                                       |
```

## List

### rST source:

```rst
1. Use ``FromSlice`` to construct a stream of int slice.
2. Use ``Filter`` to filter the zero values.
3. Use ``ToSlice`` convered filtered stream to slice, evaluation is done here.
```

### Generated markdown:

```md
1. Use `FromSlice` to construct a stream of int slice.


2. Use `Filter` to filter the zero values.


3. Use `ToSlice` convered filtered stream to slice, evaluation is done here.
```

### After this patch:

```md
1. Use `FromSlice` to construct a stream of int slice.
2. Use `Filter` to filter the zero values.
3. Use `ToSlice` convered filtered stream to slice, evaluation is done here.
```