### PR TITLE
better python signatures fence

### DIFF
--- a/sphinx_markdown_builder/markdown_writer.py
+++ b/sphinx_markdown_builder/markdown_writer.py
@@ -97,7 +97,7 @@ class MarkdownTranslator(Translator):
 
     def depart_desc_signature(self, node):
         # the main signature of class/method
-        self.add(')```\n')
+        self.add(')\n```\n')
 
     def visit_desc_parameterlist(self, node):
         # method/class ctor param list

--- a/sphinx_markdown_builder/markdown_writer.py
+++ b/sphinx_markdown_builder/markdown_writer.py
@@ -97,7 +97,7 @@ class MarkdownTranslator(Translator):
 
     def depart_desc_signature(self, node):
         # the main signature of class/method
-        self.add(')\n```\n')
+        self.add(')\n```\n\n')
 
     def visit_desc_parameterlist(self, node):
         # method/class ctor param list

--- a/sphinx_markdown_builder/markdown_writer.py
+++ b/sphinx_markdown_builder/markdown_writer.py
@@ -91,13 +91,13 @@ class MarkdownTranslator(Translator):
         # If signature has a non null class, thats means it is a signature
         # of a class method
         if ("class" in node.attributes and node.attributes["class"]):
-            self.add('\n#### ')
+            self.add('\n```python\n')
         else:
-            self.add('\n### ')
+            self.add('\n```python\n')
 
     def depart_desc_signature(self, node):
         # the main signature of class/method
-        self.add(')\n')
+        self.add(')```\n')
 
     def visit_desc_parameterlist(self, node):
         # method/class ctor param list


### PR DESCRIPTION
This PR is a syntax suggestion for python docs.
I'm using your package to build my doc as a README.md for the repo of my python package. In my case function signatures look a lot better using this syntax. 
\`\`\`python
signature(argument)
\`\`\`
I understand your package is being used for multiple languages hence this PR can not be merged as is.   

Thank you for your package !
