### PR TITLE
Resolve excessive/missing line breaks in tables/list_items/images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,5 @@ venv.bak/
 README.rst
 *.deb
 .tern-port
+
+.idea

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-html2text>=2019.8.11
-pydash>=4.7.5
 sphinx>=2.2.0
 unify>=0.5
 yapf>=0.28.0
+tabulate
+docutils

--- a/sphinx_markdown_builder/__init__.py
+++ b/sphinx_markdown_builder/__init__.py
@@ -1,4 +1,7 @@
 from .markdown_builder import MarkdownBuilder
 
+
 def setup(app):
     app.add_builder(MarkdownBuilder)
+    app.add_config_value("markdown_http_base", "", False)
+    app.add_config_value("markdown_uri_doc_suffix", ".md", False)

--- a/sphinx_markdown_builder/contexts.py
+++ b/sphinx_markdown_builder/contexts.py
@@ -1,0 +1,106 @@
+"""
+Context handlers.
+"""
+from tabulate import tabulate
+
+
+class SubContext:
+    def __init__(self, node):
+        self.node = node
+        self.body = []
+
+    def add(self, value: str):
+        self.body.append(value)
+
+    def make(self):
+        return "".join(self.body)
+
+
+class AnnotationContext(SubContext):
+    def make(self):
+        content = super().make()
+        # We want to make the text italic. We need to make sure the _ mark is near a non-space char,
+        # but we want to preserve the existing spaces.
+        prefix_spaces = len(content) - len(content.lstrip())
+        suffix_spaces = len(content) - len(content.rstrip())
+        annotation_mark = "_"
+        content = (
+            f"{annotation_mark:>{prefix_spaces + 1}}"
+            f"{content[prefix_spaces:len(content) - suffix_spaces]}"
+            f"{annotation_mark:<{suffix_spaces + 1}}"
+        )
+        return content
+
+
+class TableContext(SubContext):
+    def __init__(self, node):
+        super().__init__(node)
+        self.headers = []
+
+        self.is_head = False
+        self.is_body = False
+        self.is_row = False
+        self.is_entry = False
+
+    @property
+    def active_output(self):
+        if self.is_head:
+            return self.headers
+        else:
+            assert self.is_body
+            return self.body
+
+    def enter_head(self):
+        assert not self.is_body
+        self.is_head = True
+
+    def exit_head(self):
+        assert self.is_head
+        self.is_head = False
+
+    def enter_body(self):
+        assert not self.is_head
+        self.is_body = True
+
+    def exit_body(self):
+        assert self.is_body
+        self.is_body = False
+
+    def enter_row(self):
+        assert self.is_head or self.is_body
+        self.is_row = True
+        self.active_output.append([])
+
+    def exit_row(self):
+        assert self.is_row
+        self.is_row = False
+
+    def enter_entry(self):
+        assert self.is_row
+        self.is_entry = True
+        self.active_output[-1].append([])
+
+    def exit_entry(self):
+        assert self.is_entry
+        self.is_entry = False
+
+    def add(self, value: str):
+        assert self.is_entry
+        self.active_output[-1][-1].append(value)
+
+    @staticmethod
+    def make_row(row):
+        return ["".join(entries) for entries in row]
+
+    def make(self):
+        if len(self.headers) == 0 and len(self.body) == 0:
+            return ""
+
+        if len(self.headers) == 0:
+            headers = [""]
+        else:
+            assert len(self.headers) == 1
+            headers = self.make_row(self.headers[0])
+
+        body = list(map(self.make_row, self.body))
+        return tabulate(body, headers=headers, tablefmt="github")

--- a/sphinx_markdown_builder/depth.py
+++ b/sphinx_markdown_builder/depth.py
@@ -1,12 +1,13 @@
 class Depth:
-    depth = 0
 
-    sub_depth = {}
+    def __init__(self):
+        self.depth = 0
+        self.sub_depth = {}
 
     def get(self, name=None):
         if name:
             return self.sub_depth[name] if name in self.sub_depth else 0
-        return depth
+        return self.depth
 
     def descend(self, name=None):
         self.depth = self.depth + 1

--- a/sphinx_markdown_builder/doctree2md.py
+++ b/sphinx_markdown_builder/doctree2md.py
@@ -485,7 +485,7 @@ class Translator(nodes.NodeVisitor):
             parent.next_node(descend=False, siblings=True), nodes.list_item
         ):
             return
-        # List item following a sub list ==> new new line
+        # List item following a sub list ==> no new line
         # <bullet_list bullet="-">
         #   <list_item>
         #     <paragraph> <== we are here

--- a/sphinx_markdown_builder/doctree2md.py
+++ b/sphinx_markdown_builder/doctree2md.py
@@ -461,16 +461,11 @@ class Translator(nodes.NodeVisitor):
 
     @classmethod
     def is_paragraph_requires_eol(cls, node):
-        parent = node.parent
-        # Table entry ==> No new line.
-        if isinstance(parent, nodes.entry):
-            return False
-
-        # List item ==> No new line. It is handled at its visit/depart handlers
-        if isinstance(parent, nodes.list_item):
-            return False
-
-        return True
+        """
+        - Table entry ==> No new line
+        - List item   ==> New line is handled at the list item visit/depart handlers
+        """
+        return not isinstance(node.parent, (nodes.entry, nodes.list_item))
 
     def visit_paragraph(self, node):
         if self.is_paragraph_requires_eol(node):

--- a/sphinx_markdown_builder/doctree2md.py
+++ b/sphinx_markdown_builder/doctree2md.py
@@ -459,44 +459,24 @@ class Translator(nodes.NodeVisitor):
 
     depart_field_body = depart_definition
 
-    def visit_paragraph(self, node):
-        pass
-
-    def depart_paragraph(self, node):
+    @classmethod
+    def is_paragraph_requires_eol(cls, node):
         parent = node.parent
-        # Table entry ==> no new line
-        # <row>
-        #   <entry>
-        #     <paragraph> <== we are here
+        # Table entry ==> No new line.
         if isinstance(parent, nodes.entry):
-            return
-        # Non-last list item ==> no new line
-        # <bullet_list bullet="-">
-        #   <list_item>
-        #     <paragraph> <== we are here
-        #   <list_item>
-        #     <paragraph>
-        if isinstance(
-            parent, nodes.list_item
-        ) and isinstance(
-            parent.next_node(descend=False, siblings=True), nodes.list_item
-        ):
-            return
-        # List item following a sub list ==> no new line
-        # <bullet_list bullet="-">
-        #   <list_item>
-        #     <paragraph> <== we are here
-        #       <bullet_list bullet="*">
-        #         <list_item>
-        #           <paragraph>
-        if isinstance(
-            parent, nodes.list_item
-        ) and isinstance(
-            node.next_node(descend=False, siblings=True), nodes.bullet_list
-        ):
-            return
+            return False
 
-        self.ensure_eol(2)
+        # List item ==> No new line. It is handled at its visit/depart handlers
+        if isinstance(parent, nodes.list_item):
+            return False
+
+        return True
+
+    def visit_paragraph(self, node):
+        if self.is_paragraph_requires_eol(node):
+            self.ensure_eol(2)
+
+    depart_paragraph = visit_paragraph
 
     def visit_math_block(self, node):
         # docutils math block

--- a/sphinx_markdown_builder/doctree2md.py
+++ b/sphinx_markdown_builder/doctree2md.py
@@ -308,11 +308,8 @@ class Translator(nodes.NodeVisitor):
         self.settings = settings = document.settings
         lcode = settings.language_code
         self.language = languages.get_language(lcode, document.reporter)
-        # Not-None here indicates Markdown should use HTTP for internal and
-        # download links.
-        self.markdown_http_base = (
-            builder.markdown_http_base if builder else None
-        )
+        # Not-None here indicates Markdown should use HTTP for internal and download links.
+        self.markdown_http_base = builder.config.markdown_http_base if builder else None
         # Warn only once per writer about unsupported elements
         self._warned = set()
         # Lookup table to get section list from name

--- a/sphinx_markdown_builder/markdown_builder.py
+++ b/sphinx_markdown_builder/markdown_builder.py
@@ -1,11 +1,13 @@
-from .markdown_writer import MarkdownWriter, MarkdownTranslator
-from docutils.io import StringOutput
 from io import open
 from os import path
+
+from docutils.io import StringOutput
 from sphinx.builders import Builder
 from sphinx.locale import __
 from sphinx.util import logging
 from sphinx.util.osutil import ensuredir, os_path
+
+from .markdown_writer import MarkdownWriter, MarkdownTranslator
 
 logger = logging.getLogger(__name__)
 

--- a/sphinx_markdown_builder/markdown_builder.py
+++ b/sphinx_markdown_builder/markdown_builder.py
@@ -16,13 +16,11 @@ class MarkdownBuilder(Builder):
     format = 'markdown'
     epilog = __('The markdown files are in %(outdir)s.')
 
-    out_suffix = '.md'
     allow_parallel = True
     default_translator_class = MarkdownTranslator
 
+    out_suffix = '.md'
     current_docname = None
-
-    markdown_http_base = 'https://localhost'
     insert_anchors_for_signatures = False
 
     def init(self):
@@ -46,8 +44,12 @@ class MarkdownBuilder(Builder):
                 pass
 
     def get_target_uri(self, docname: str, typ=None):
-        # Returns the target markdown file name
-        return f"{docname}.md"
+        """
+        Returns the target file name.
+        By default, we link to the currently generated markdown files.
+        But, we also support linking to external document (e.g., an html web page).
+        """
+        return f"{docname}{self.config.markdown_uri_doc_suffix}"
 
     def prepare_writing(self, docnames):
         self.writer = MarkdownWriter(self)

--- a/sphinx_markdown_builder/markdown_writer.py
+++ b/sphinx_markdown_builder/markdown_writer.py
@@ -370,7 +370,6 @@ class MarkdownTranslator(Translator):
     def depart_row(self, node):
         self.cur_table().exit_row()
 
-
     def visit_entry(self, node):
         self.cur_table().enter_entry()
 
@@ -411,7 +410,7 @@ class MarkdownTranslator(Translator):
 
     def depart_list_item(self, node):
         self.depth.ascend('list_item')
-        # Make sure the list item end with a new line
+        # Make sure the list item ends with a new line
         self.ensure_eol()
 
     def descend(self, node_name):

--- a/sphinx_markdown_builder/markdown_writer.py
+++ b/sphinx_markdown_builder/markdown_writer.py
@@ -214,7 +214,13 @@ class MarkdownTranslator(Translator):
             uri = uri[len(doc_folder):]
             if uri.startswith('/'):
                 uri = '.' + uri
-        self.add('\n\n![image](%s)\n\n' % uri)
+
+        image_tag = f'![image]({uri})'
+        if not isinstance(node.parent, nodes.paragraph):
+            # Adress the case that the image is part of a reference
+            self.add(image_tag)
+        else:
+            self.add(f'\n\n{image_tag}\n\n')
 
     def depart_image(self, node):
         """Image directive."""
@@ -288,7 +294,7 @@ class MarkdownTranslator(Translator):
             raise nodes.SkipNode
         self.theads.append(node)
 
-    def depart_thead(self, node):
+    def add_table_header_split(self):
         for i in range(len(self.table_entries)):
             length = 0
             for row in self.table_rows:
@@ -299,6 +305,9 @@ class MarkdownTranslator(Translator):
             self.add('| ' + ''.join(_.map(range(length), lambda: '-')) + ' ')
         self.add('|\n')
         self.table_entries = []
+
+    def depart_thead(self, node):
+        self.add_table_header_split()
         self.theads.pop()
 
     def visit_tbody(self, node):

--- a/sphinx_markdown_builder/markdown_writer.py
+++ b/sphinx_markdown_builder/markdown_writer.py
@@ -399,7 +399,7 @@ class MarkdownTranslator(Translator):
     def visit_list_item(self, node):
         self.depth.descend('list_item')
         depth = self.depth.get('list')
-        depth_padding = ''.join(['    ' for i in range(depth - 1)])
+        depth_padding = '    ' * (depth - 1)
         marker = '*'
         if node.parent.tagname == 'enumerated_list':
             if depth not in self.enumerated_count:
@@ -407,10 +407,14 @@ class MarkdownTranslator(Translator):
             else:
                 self.enumerated_count[depth] = self.enumerated_count[depth] + 1
             marker = str(self.enumerated_count[depth]) + '.'
-        self.add('\n' + depth_padding + marker + ' ')
+        # Make sure the list item prefix starts at a new line
+        self.ensure_eol()
+        self.add(depth_padding + marker + " ")
 
     def depart_list_item(self, node):
         self.depth.ascend('list_item')
+        # Make sure the list item end with a new line
+        self.ensure_eol()
 
     def descend(self, node_name):
         self.depth.descend(node_name)

--- a/sphinx_markdown_builder/markdown_writer.py
+++ b/sphinx_markdown_builder/markdown_writer.py
@@ -274,12 +274,10 @@ class MarkdownTranslator(Translator):
             if uri.startswith('/'):
                 uri = '.' + uri
 
-        image_tag = f'![image]({uri})'
-        if not isinstance(node.parent, nodes.paragraph):
-            # Adress the case that the image is part of a reference
-            self.add(image_tag)
-        else:
-            self.add(f'\n\n{image_tag}\n\n')
+        alt = node.attributes.get('alt', 'image')
+        # We don't need to add EOL before/after the image.
+        # It will be handled by the visit/depart handlers of the paragraph.
+        self.add(f'![{alt}]({uri})')
 
     def depart_image(self, node):
         """Image directive."""


### PR DESCRIPTION
Related issues/PRs: #61, #57, #56.

I address these issues by applying the following changes:
- `ensure_eol()` now supports an optional number of lines.
- Add calls the `ensure_eol()` before content that must begin in a new line (e.g., headers, code, and more).
- Add calls the `ensure_eol()` instead of directly adding "\n" whenever possible to avoid redundant line breaks.
- Each paragraph ensures there are two EOL before and after the paragraph. Except for:
  - entry: We don't want to add line breaks in a table's entry.
  - list_item/field_name/field_body: EOL is handled at the list_item's visit/depart handlers.
- Images do not add EOL before/after the image. The paragraph that contains the image ensures the needed EOLs.
  This allows support for the cases the image is inside a reference/table/etc.
- Tables are aggregated in a sub context, then dumped as a table using [`tabulate`](https://pypi.org/project/tabulate).
- Annotations are aggregated in a sub-context, then _..._ is added before the dump.

Other changes:
- Added support for image alt text.
- Added two configuration options:
  - `markdown_http_base`: allow setting a prefix for the URL of references.
  - `markdown_uri_doc_suffix`: allow linking to a different doc suffix (e.g., html), to support linking to an external documentation webpage. 
- Minor bug fixes.